### PR TITLE
Remove non-BSD (and unknown) escape from a BSD manual page.

### DIFF
--- a/man7/mdoc.7
+++ b/man7/mdoc.7
@@ -343,7 +343,7 @@ Produces
 .It Li \&Bo Ta Yes Ta Yes Ta "Bracket open quote."
 .It Li \&Bq Ta Yes Ta Yes Ta "Bracket quote."
 .It Li \&Bx Ta Yes Ta Yes Ta Bx .
-.It Li \&Db Ta \&No Ta \&No Ta "Debug (default is \*qoff\*q)"
+.It Li \&Db Ta \&No Ta \&No Ta "Debug (default is off)"
 .It Li \&Dc Ta Yes Ta Yes Ta "Double close quote."
 .It Li \&Do Ta Yes Ta Yes Ta "Double open quote."
 .It Li \&Dq Ta Yes Ta Yes Ta "Double quote."
@@ -368,7 +368,7 @@ Produces
 .It Li \&Sc Ta Yes Ta Yes Ta "Single close quote."
 .It Li \&So Ta Yes Ta Yes Ta "Single open quote."
 .It Li \&Sq Ta Yes Ta Yes Ta "Single quote."
-.It Li \&Sm Ta \&No Ta \&No Ta "Space mode (default is \\*qon\\*q)"
+.It Li \&Sm Ta \&No Ta \&No Ta "Space mode (default is on)"
 .It Li \&Sx Ta Yes Ta Yes Ta "Section Cross Reference."
 .It Li \&Sy Ta Yes Ta Yes Ta "Symbolic (traditional English)."
 .It Li \&Tn Ta Yes Ta Yes Ta "Trade or type name (small Caps)."


### PR DESCRIPTION
roff ignores this, but it messes up doclifter translation.