### PR TITLE
semop.2, proc.5, cgroup_namespaces.7, cgroups.7: Fix scrambled scopes

### DIFF
--- a/man2/seccomp.2
+++ b/man2/seccomp.2
@@ -881,8 +881,6 @@ when the filters cause unexpected failures for legitimate operations
 that the application might need to perform.
 Such bugs may not easily be discovered when testing the seccomp
 filters if the bugs occur in rarely used application code paths.
-.RS 3
-.\"
 .SS Seccomp-specific BPF details
 Note the following BPF details specific to seccomp filters:
 .IP * 3

--- a/man2/semop.2
+++ b/man2/semop.2
@@ -64,8 +64,8 @@ unsigned short  semval;   /* semaphore value */
 unsigned short  semzcnt;  /* # waiting for zero */
 unsigned short  semncnt;  /* # waiting for increase */
 pid_t           sempid;   /* PID of process that last
-.in
 .EE
+.in
 .PP
 .BR semop ()
 performs operations on selected semaphores in the set indicated by

--- a/man5/proc.5
+++ b/man5/proc.5
@@ -1232,8 +1232,8 @@ The file contains lines of the form:
 .EX
 36 35 98:0 /mnt1 /mnt2 rw,noatime master:1 \- ext3 /dev/root rw,errors=continue
 (1)(2)(3)   (4)   (5)      (6)      (7)   (8) (9)   (10)         (11)
-.in
 .EE
+.in
 .IP
 The numbers in parentheses are labels for the descriptions below:
 .RS 7

--- a/man7/cgroup_namespaces.7
+++ b/man7/cgroup_namespaces.7
@@ -86,11 +86,11 @@ Next, we use
 .BR unshare (1)
 to create a process running a new shell in new cgroup and mount namespaces:
 .PP
-.EX
 .in +4n
+.EX
 # \fBunshare \-Cm bash\fP
-.in
 .EE
+.in
 .PP
 We then inspect the
 .IR /proc/[pid]/cgroup
@@ -101,16 +101,16 @@ command, a process that is in the original cgroup namespace
 with PID 1), and a process in a sibling cgroup
 .RI ( sub2 ):
 .PP
-.EX
 .in +4n
+.EX
 $ \fBcat /proc/self/cgroup | grep freezer\fP
 7:freezer:/
 $ \fBcat /proc/1/cgroup | grep freezer\fP
 7:freezer:/..
 $ \fBcat /proc/20124/cgroup | grep freezer\fP
 7:freezer:/../sub2
-.in
 .EE
+.in
 .PP
 From the output of the first command,
 we see that the freezer cgroup membership of the new shell
@@ -130,12 +130,12 @@ However, when we look in
 .IR /proc/self/mountinfo
 we see the following anomaly:
 .PP
-.EX
 .in +4n
+.EX
 # \fBcat /proc/self/mountinfo | grep freezer\fP
 155 145 0:32 /.. /sys/fs/cgroup/freezer ...
-.in
 .EE
+.in
 .PP
 The fourth field of this line
 .RI ( /.. )
@@ -151,16 +151,16 @@ filesystem corresponding to our initial shell process's cgroup namespace
 We need to remount the freezer cgroup filesystem
 inside this cgroup namespace, after which we see the expected results:
 .PP
-.EX
 .in +4n
+.EX
 # \fBmount \-\-make\-rslave /\fP     # Don't propagate mount events
                             # to other namespaces
 # \fBumount /sys/fs/cgroup/freezer\fP
 # \fBmount \-t cgroup \-o freezer freezer /sys/fs/cgroup/freezer\fP
 # \fBcat /proc/self/mountinfo | grep freezer\fP
 155 145 0:32 / /sys/fs/cgroup/freezer rw,relatime ...
-.in
 .EE
+.in
 .PP
 Use of cgroup namespaces requires a kernel that is configured with the
 .B CONFIG_CGROUPS

--- a/man7/cgroups.7
+++ b/man7/cgroups.7
@@ -1679,14 +1679,14 @@ and this file provides a way for the kernel to inform
 user-space applications of which files must be delegated.
 As at Linux 4.15, one sees the following when inspecting this file:
 .IP
-.EX
 .in +4n
+.EX
 $ \fBcat /sys/kernel/cgroup/delegate\fP
 cgroup.procs
 cgroup.subtree_control
 cgroup.threads
-.in
 .EE
+.in
 .TP
 .IR /sys/kernel/cgroup/features " (since Linux 4.15)"
 .\" commit 5f2e673405b742be64e7c3604ed4ed3ac14f35ce

--- a/man7/inode.7
+++ b/man7/inode.7
@@ -238,7 +238,7 @@ and the least significant 9 bits (0777) as the
 .IR "file permission bits" .
 .PP
 The following mask values are defined for the file type:
-.in +4n
+.RS
 .TS
 lB l l.
 S_IFMT	0170000	bit mask for the file type bit field
@@ -251,18 +251,18 @@ S_IFDIR	0040000	directory
 S_IFCHR	0020000	character device
 S_IFIFO	0010000	FIFO
 .TE
-.in
+.RE
 .PP
 Thus, to test for a regular file (for example), one could write:
 .PP
-.in +4n
+.RS
 .EX
 stat(pathname, &sb);
 if ((sb.st_mode & S_IFMT) == S_IFREG) {
     /* Handle regular file */
 }
 .EE
-.in
+.RE
 .PP
 Because tests of the above form are common, additional
 macros are defined by POSIX to allow the test of the file type in
@@ -294,14 +294,14 @@ socket?  (Not in POSIX.1-1996.)
 .PP
 The preceding code snippet could thus be rewritten as:
 .PP
-.in +4n
+.RS
 .EX
 stat(pathname, &sb);
 if (S_ISREG(sb.st_mode)) {
     /* Handle regular file */
 }
 .EE
-.in
+.RE
 .PP
 The definitions of most of the above file type test macros
 are provided if any of the following feature test macros is defined:
@@ -348,7 +348,7 @@ The following mask values are defined for
 the file mode component of the
 .I st_mode
 field:
-.in +4n
+.RS
 .TS
 lB l l.
 S_ISUID	  04000	set-user-ID bit
@@ -372,7 +372,7 @@ S_IROTH	  00004	others have read permission
 S_IWOTH	  00002	others have write permission
 S_IXOTH	  00001	others have execute permission
 .TE
-.in
+.RE
 .PP
 The set-group-ID bit
 .RB ( S_ISGID )

--- a/man8/zic.8
+++ b/man8/zic.8
@@ -41,8 +41,9 @@ Use the given timezone as local time.
 .B zic
 will act as if the input contained a link line of the form
 .PP
-.ti +.5i
+.EX
 Link	\fItimezone\fP		localtime
+.EE
 .TP
 .BI "\-p " timezone
 Use the given timezone's rules when handling POSIX-format
@@ -50,8 +51,9 @@ timezone environment variables.
 .B zic
 will act as if the input contained a link line of the form
 .PP
-.ti +.5i
+.EX
 Link	\fItimezone\fP		posixrules
+.EE
 .TP
 .BI "\-L " leapsecondfilename
 Read leap second information from the file with the given name.
@@ -87,21 +89,16 @@ Any line that is blank (after comment stripping) is ignored.
 Nonblank lines are expected to be of one of three types:
 rule lines, zone lines, and link lines.
 .PP
-A rule line has the form
-.nf
-.ti +.5i
-.ta \w'Rule\0\0'u +\w'NAME\0\0'u +\w'FROM\0\0'u +\w'1973\0\0'u +\w'TYPE\0\0'u +\w'Apr\0\0'u +\w'lastSun\0\0'u +\w'2:00\0\0'u +\w'SAVE\0\0'u
-.PP
+The following table shows a rule line with field names above it.
+.TS
+l l l l l l l l l l.
 Rule	NAME	FROM	TO	TYPE	IN	ON	AT	SAVE	LETTER/S
-.PP
-For example:
-.ti +.5i
-.PP
 Rule	US	1967	1973	\-	Apr	lastSun	2:00	1:00	D
+.TE
 .PP
 .fi
 The fields that make up a rule line are:
-.TP "\w'LETTER/S'u"
+.TP
 .B NAME
 Gives the (arbitrary) name of the set of rules this rule is part of.
 .TP
@@ -148,11 +145,11 @@ If
 is something else, then
 .I zic
 executes the command
-.ti +.5i
+.RS
 .B yearistype
 .I year
 .I type
-.br
+.RE
 to check the type of a year:
 an exit status of zero is taken to mean that the year is of the given type;
 an exit status of one is taken to mean that the year is not of the given type.
@@ -164,17 +161,14 @@ Month names may be abbreviated.
 .B ON
 Gives the day on which the rule takes effect.
 Recognized forms include:
-.nf
-.in +.5i
-.PP
-.ta \w'Sun<=25\0\0'u
+.TS
+l l.
 5	the fifth of the month
 lastSun	the last Sunday in the month
 lastMon	the last Monday in the month
 Sun>=8	first Sunday on or after the eighth
 Sun<=25	last Sunday on or before the 25th
-.fi
-.in -.5i
+.TE
 .PP
 Names of days of the week may be abbreviated or spelled out in full.
 Note that there must be no spaces within the
@@ -184,17 +178,14 @@ field.
 .B AT
 Gives the time of day at which the rule takes effect.
 Recognized forms include:
-.nf
-.in +.5i
-.PP
-.ta \w'1:28:13\0\0'u
+.TS
+l l.
 2	time in hours
 2:00	time in hours and minutes
 15:00	24-hour format time (for times after noon)
 1:28:14	time in hours, minutes, and seconds
 \-	equivalent to 0
-.fi
-.in -.5i
+.TE
 .PP
 where hour 0 is midnight at the start of the day,
 and hour 24 is midnight at the end of the day.
@@ -244,21 +235,18 @@ If this field is
 .BR \- ,
 the variable part is null.
 .PP
-A zone line has the form
+A zone line has the form shown in the following table.  The first row
+is field names, the second fields of the zone line.
 .PP
-.nf
-.ti +.5i
-.ta \w'Zone\0\0'u +\w'Australia/Adelaide\0\0'u +\w'UTCOFF\0\0'u +\w'RULES/SAVE\0\0'u +\w'FORMAT\0\0'u
+.TS
+l l l l l l.
 Zone	NAME	UTCOFF	RULES/SAVE	FORMAT	[UNTIL]
-.PP
-For example:
-.PP
-.ti +.5i
 Zone	Australia/Adelaide	9:30	Aus	CST	1971 Oct 31 2:00
+.TE
 .PP
 .fi
 The fields that make up a zone line are:
-.TP "\w'UTCOFF'u"
+.TP
 .B NAME
 The name of the timezone.
 This is the name used in creating the time conversion information file for the
@@ -315,17 +303,14 @@ Continuation lines may contain an
 field, just as zone lines do, indicating that the next line is a further
 continuation.
 .PP
-A link line has the form
+A link line has the form shown in the following table.  The first line
+is field names, the second example field values in an example line.
 .PP
-.nf
-.ti +.5i
-.ta \w'Link\0\0'u +\w'Europe/Istanbul\0\0'u
+.TS
+l l l.
 Link	LINK-FROM	LINK-TO
-.PP
-For example:
-.PP
-.ti +.5i
 Link	Europe/Istanbul	Asia/Istanbul
+.TE
 .PP
 .fi
 The
@@ -340,17 +325,14 @@ field is used as an alternate name for that zone.
 Except for continuation lines,
 lines may appear in any order in the input.
 .PP
-Lines in the file that describes leap seconds have the following form:
-.nf
-.ti +.5i
-.ta \w'Leap\0\0'u +\w'YEAR\0\0'u +\w'MONTH\0\0'u +\w'DAY\0\0'u +\w'HH:MM:SS\0\0'u +\w'CORR\0\0'u
-.PP
+Lines in the file that describes leap seconds have form
+shown in the following table.  The first line
+is field names, the second example field values in an example line.
+.TS
+l l l l l l l.
 Leap	YEAR	MONTH	DAY	HH:MM:SS	CORR	R/S
-.PP
-For example:
-.ti +.5i
-.PP
 Leap	1974	Dec	31	23:59:60	+	S
+.TE
 .PP
 .fi
 The


### PR DESCRIPTION
The manpages commonly use .in +4/.EX....EE/.in pairs for iindented examples.

Clean up four exceptional instances out of hundreds in which the .in
was the inner operation rather than the outer. No difference in
rendering, but the uniformity makes it possible to parse these
mechanically with one rule.

Really all these ought to be replaced with .RS/.EX....EE/.RE but
doclifter can cope given this less intrusive change.