### PR TITLE
sched_setaffinity.2: sched_getaffinity returns the number of bytes copied

### DIFF
--- a/man2/sched_setaffinity.2
+++ b/man2/sched_setaffinity.2
@@ -107,9 +107,9 @@ is zero, then the mask of the calling thread is returned.
 .SH RETURN VALUE
 On success,
 .BR sched_setaffinity ()
-and
+returns 0, while
 .BR sched_getaffinity ()
-return 0.
+returns the number of bytes copied to the destination mask.
 On error, \-1 is returned, and
 .I errno
 is set appropriately.


### PR DESCRIPTION
Signed-off-by: Brice Goglin <Brice.Goglin@inria.fr>