### PR TITLE
Update CPU_SET.3

### DIFF
--- a/man3/CPU_SET.3
+++ b/man3/CPU_SET.3
@@ -87,7 +87,7 @@ and similar interfaces.
 The
 .I cpu_set_t
 data type is implemented as a bit mask.
-However, the data structure treated as considered opaque:
+However, the data structure should be treated as opaque:
 all manipulation of CPU sets should be done via the macros
 described in this page.
 .PP


### PR DESCRIPTION
Small update to wording

http://man7.org/linux/man-pages/man3/CPU_SET.3.html

cpu_set_t data type is implemented as a bit mask.  However, the
data structure treated as considered opaque: all manipulation of CPU
sets should be done via the macros described in this page.