### PR TITLE
symlink.7: fchmodat cannot be used on a fd

### DIFF
--- a/man7/symlink.7
+++ b/man7/symlink.7
@@ -134,7 +134,6 @@ yields a file descriptor that can be passed as the
 argument in system calls such as
 .BR fstatat (2),
 .BR fchownat (2),
-.BR fchmodat (2),
 .BR linkat (2),
 and
 .BR readlinkat (2),


### PR DESCRIPTION
Remove fchmodat from the list of syscalls than can operate on a symbolic link file descriptor.