### PR TITLE
Changed definition of the possibile return value "NULL"

### DIFF
--- a/man3/malloc.3
+++ b/man3/malloc.3
@@ -69,7 +69,7 @@ If
 .I size
 is 0, then
 .BR malloc ()
-returns either NULL,
+returns a value equal to NULL,
 .\" glibc does this:
 or a unique pointer value that can later be successfully passed to
 .BR free ().
@@ -88,7 +88,7 @@ Otherwise, or if
 has already been called before, undefined behavior occurs.
 If
 .I ptr
-is NULL, no operation is performed.
+is equal to NULL, no operation is performed.
 .PP
 The
 .BR calloc ()
@@ -104,7 +104,7 @@ or
 .I size
 is 0, then
 .BR calloc ()
-returns either NULL,
+returns a value equal to NULL,
 .\" glibc does this:
 or a unique pointer value that can later be successfully passed to
 .BR free ().
@@ -140,7 +140,7 @@ If the new size is larger than the old size, the added memory will
 be initialized.
 If
 .I ptr
-is NULL, then the call is equivalent to
+is equal to NULL, then the call is equivalent to
 .IR malloc(size) ,
 for all values of
 .IR size ;
@@ -149,11 +149,11 @@ if
 is equal to zero,
 and
 .I ptr
-is not NULL, then the call is equivalent to
+is not equal to NULL, then the call is equivalent to
 .IR free(ptr) .
 Unless
 .I ptr
-is NULL, it must have been returned by an earlier call to
+is equal to NULL, it must have been returned by an earlier call to
 .BR malloc (),
 .BR calloc (),
 or
@@ -184,7 +184,7 @@ call,
 fails safely in the case where the multiplication would overflow.
 If such an overflow occurs,
 .BR reallocarray ()
-returns NULL, sets
+returns a value equal to NULL, sets
 .I errno
 to
 .BR ENOMEM ,
@@ -196,8 +196,8 @@ and
 .BR calloc ()
 functions return a pointer to the allocated memory,
 which is suitably aligned for any built-in type.
-On error, these functions return NULL.
-NULL may also be returned by a successful call to
+On error, these functions returns a value equal to NULL.
+A value equal to NULL may also be returned by a successful call to
 .BR malloc ()
 with a
 .I size
@@ -217,7 +217,7 @@ function returns no value.
 The
 .BR realloc ()
 function returns a pointer to the newly allocated memory, which is suitably
-aligned for any built-in type, or NULL if the request failed.
+aligned for any built-in type, or a value not equal to NULL if the request failed.
 The returned pointer may be the same as
 .IR ptr
 if the allocation was not moved
@@ -226,7 +226,7 @@ if the allocation was not moved
 if the allocation was moved to a new address.
 If
 .I size
-was equal to 0, either NULL or a pointer suitable to be passed to
+was equal to 0, either a value equal to NULL or a pointer suitable to be passed to
 .BR free ()
 is returned.
 If
@@ -237,7 +237,7 @@ On success, the
 .BR reallocarray ()
 function returns a pointer to the newly allocated memory.
 On failure,
-it returns NULL and the original block of memory is left untouched.
+it returns a value equal to NULL and the original block of memory is left untouched.
 .SH ERRORS
 .BR calloc (),
 .BR malloc (),
@@ -283,7 +283,7 @@ is a nonstandard extension that first appeared in OpenBSD 5.6 and FreeBSD 11.0.
 By default, Linux follows an optimistic memory allocation strategy.
 This means that when
 .BR malloc ()
-returns non-NULL there is no guarantee that the memory really
+returns a value not equal to NULL there is no guarantee that the memory really
 is available.
 In case it turns out that the system is out of memory,
 one or more processes will be killed by the OOM killer.


### PR DESCRIPTION
Hi, I teach (student assistant) Systems Level Programming on the Technical Univerity of Graz.
I noticed students get confused by the difference 0 and NULL. To make sure NULL is not confused with an actual type value, which can be returned by  malloc/calloc... I would change the "returns NULL" to "a value equal to NULL".
