### PR TITLE
Update proc.5

### DIFF
--- a/man5/proc.5
+++ b/man5/proc.5
@@ -1399,8 +1399,11 @@ Under Linux 2.0, there is no field giving pathname.
 This file can be used to access the pages of a process's memory through
 .BR open (2),
 .BR read (2),
+.BR write(2),
 and
 .BR lseek (2).
+.IP
+Permission to use the write(2) syscall is allowed only if the caller of write(2) is the parent process of the [pid] to be written.
 .IP
 Permission to access this file is governed by a ptrace access mode
 .B PTRACE_MODE_ATTACH_FSCREDS


### PR DESCRIPTION
Since 2011, /proc/pid/mem interface is possible to be written via write(2) syscall:

https://lwn.net/Articles/432347/

https://lwn.net/Articles/433326/

An example where this feature is used is in the Google CTF 2020 "WriteOnly" challenge.