### PR TITLE
execve.2: Segment should be rename to sections depends on definitions…

### DIFF
--- a/man2/execve.2
+++ b/man2/execve.2
@@ -49,7 +49,7 @@ execve \- execute program
 executes the program referred to by \fIpathname\fP.
 This causes the program that is currently being run by the calling process
 to be replaced with a new program, with newly initialized stack, heap,
-and (initialized and uninitialized) data segments.
+and (initialized and uninitialized) data sections.
 .PP
 \fIpathname\fP must be either a binary executable, or a script
 starting with a line of the form:


### PR DESCRIPTION
'segments' should be rename to 'sections' depends on definitions in ELF systems.
For more : https://man7.org/linux/man-pages/man5/elf.5.html