### PR TITLE
Clarify CLONE_VFORK doc

### DIFF
--- a/man2/clone.2
+++ b/man2/clone.2
@@ -1154,7 +1154,7 @@ on this child process.
 .BR CLONE_VFORK " (since Linux 2.2)"
 If
 .B CLONE_VFORK
-is set, the execution of the calling process is suspended
+is set, the execution of the calling thread is suspended
 until the child releases its virtual memory
 resources via a call to
 .BR execve (2)


### PR DESCRIPTION
"process" is confusing because it might cause people to think all threads of the parent get suspended.