### PR TITLE
execve.2: execve also returns E2BIG if a string is too long

### DIFF
--- a/man2/execve.2
+++ b/man2/execve.2
@@ -449,7 +449,12 @@ The total number of bytes in the environment
 .RI ( envp )
 and argument list
 .RI ( argv )
-is too large.
+is too large,
+an argument or environment string is too long,
+or the full
+.I pathname
+of the executable is too long.
+The terminating NUL is counted as part of the string length.
 .TP
 .B EACCES
 Search permission is denied on a component of the path prefix of


### PR DESCRIPTION
Document that if a command line or environment string is too long (> MAX_ARG_STRLEN), execve will also return E2BIG.