### PR TITLE
Correct documentation for bpf_l4_csum_replace() offset parameter

### DIFF
--- a/man7/bpf-helpers.7
+++ b/man7/bpf-helpers.7
@@ -361,8 +361,8 @@ number of bytes (2 or 4) for this field, stored on the lowest
 four bits of \fIflags\fP\&. Alternatively, it is possible to store
 the difference between the previous and the new values of the
 header field in \fIto\fP, by setting \fIfrom\fP and the four lowest
-bits of \fIflags\fP to 0. For both methods, \fIoffset\fP indicates the
-location of the IP checksum within the packet. In addition to
+bits of \fIflags\fP to 0. For both methods, \fIoffset\fP indicates the 
+location of the L4 (TCP/UDP/ICMP) checksum within the packet. In addition to
 the size of the field, \fIflags\fP can be added (bitwise OR) actual
 flags. With \fBBPF_F_MARK_MANGLED_0\fP, a null checksum is left
 untouched (unless \fBBPF_F_MARK_ENFORCE\fP is added as well), and


### PR DESCRIPTION
The bpf_l4_csum_replace() helper’s offset parameter points to the transport-layer checksum (e.g., TCP/UDP/ICMP), not the IP checksum. This change updates the misleading reference to “IP checksum” and aligns the documentation with the function’s actual behavior.