### PR TITLE
add a scenario that does not dump the core for core.5

### DIFF
--- a/man5/core.5
+++ b/man5/core.5
@@ -132,6 +132,13 @@ option.
 The kernel was configured without the
 .BR CONFIG_COREDUMP
 option.
+.IP *
+(Since Linux 3.7)
+The
+.BR RLIMIT_CORE
+(core file size) resource limits for the process are set to 1 when
+.I /proc/sys/kernel/core_pattern
+is s pipe
 .PP
 In addition,
 a core dump may exclude part of the address space of the process if the


### PR DESCRIPTION
Since 3.7, the linux kernel does not generate a core file if the core_pattern is a pipe if rlmit_core is set to 1. Detailed code can refer to https://elixir.bootlin.com/linux/v3.7/source/fs/coredump.c#L535 (line 525-535)