### PR TITLE
few changes in socket programming man pages

### DIFF
--- a/man2/bind.2
+++ b/man2/bind.2
@@ -128,6 +128,24 @@ and for
 see
 .BR netlink (7).
 .PP
+For sockets in the Internet domain (such as
+.BR AF_INET
+or
+.BR AF_INET6 ),
+the
+.I addr
+pointer is often obtained via a call to
+.BR getaddrinfo (3),
+which returns a linked list of
+.I struct addrinfo
+structures. Each node contains a pointer to a socket address suitable for passing to
+.BR bind ().
+This is the modern, protocol-independent way to obtain socket address structures for both IPv4 and IPv6, and is generally preferred over manually constructing
+.IR sockaddr_in
+or
+.IR sockaddr_in6
+structures.
+.PP
 The actual structure passed for the
 .I addr
 argument will depend on the address family.

--- a/man7/ip.7
+++ b/man7/ip.7
@@ -207,6 +207,7 @@ values
 using
 .BR htonl (3)
 or set using the
+.BR inet_pton (3),
 .BR inet_aton (3),
 .BR inet_addr (3),
 .BR inet_makeaddr (3)


### PR DESCRIPTION
Added descriptions for modern methods for bind. Methods like Inet_addr are deprecated. While there are man pages for these modern methods but no reference.